### PR TITLE
feat(pulumi-cache): remove pulumi cache in 5.19.0

### DIFF
--- a/5.19.0/index.js
+++ b/5.19.0/index.js
@@ -1,4 +1,4 @@
-const { yarnInstall } = require("../utils");
+const { yarnInstall, removePulumiCache } = require("../utils");
 
 const updateResolutions = require("./updateResolutions");
 const addActionPlugin = require("./addActionPlugin");
@@ -9,6 +9,9 @@ module.exports = async context => {
 
     // Adds a new "action" settings plugin for the Page Builder Editor.
     await addActionPlugin(context);
+    
+    // Remove pulumi cache
+	await removePulumiCache(context);
 
     /**
      * Install new packages.

--- a/utils/index.js
+++ b/utils/index.js
@@ -16,6 +16,7 @@ const removePluginFromCreateHandler = require("./removePluginFromCreateHandler")
 const removeWorkspaceToRootPackageJson = require("./removeWorkspaceToRootPackageJson");
 const yarnInstall = require("./yarnInstall");
 const yarnUp = require("./yarnUp");
+const removePulumiCache = require("./removePulumiCache");
 
 module.exports = {
     addPluginToCreateHandler,
@@ -32,5 +33,6 @@ module.exports = {
     removeImportFromSourceFile,
     removeWorkspaceToRootPackageJson,
     yarnInstall,
-    yarnUp
+    yarnUp,
+	removePulumiCache
 };

--- a/utils/removePulumiCache.js
+++ b/utils/removePulumiCache.js
@@ -1,0 +1,41 @@
+const fs = require("fs");
+const path = require("path");
+const { log } = require("./log");
+
+const pulumiCliCachePath = `.webiny/pulumi-cli`;
+
+
+const logToRemove = () => {
+	log.error(`Cannot automatically remove Pulumi CLI cache, please do it manually.`);
+	log.info(`Directory to remove: $YOUR_PROJECT_ROOT/${pulumiCliCachePath}`);
+}
+
+module.exports = async(context) => {
+	if (!context.project || !context.project.root) {
+		log.error("Missing definition for project root directory.");
+		logToRemove();
+		return;
+	}
+	
+	log.info(`Removing Pulumi CLI cache directory...`)
+	const target = path.join(context.project.root, pulumiCliCachePath);
+	if (fs.existsSync(target) !== true) {
+		log.error(`Missing directory "${pulumiCliCachePath}" in your project root.`);
+		logToRemove();
+		return;
+	}
+	
+	const renamedTarget = `${pulumiCliCachePath}.${Date.now()}`;
+	
+	const renamedTargetPath = path.join(context.project.root, renamedTarget);
+	
+	try {
+		fs.renameSync(target, renamedTargetPath);
+	} catch(ex) {
+		log.error(ex.message);
+		logToRemove();
+		
+		return;
+	}
+	log.info("Successfully remove Pulumi CLI cache directory.");
+};


### PR DESCRIPTION
## Note

Added a `removePulumiCache` helper to remove `.webiny/pulumi-cli` in the user project directory.
This is sometimes required to be done so pulumi-cli is on the version we require.