### PR TITLE
feat: add "unstable" as a valid package version

### DIFF
--- a/utils/dependencies.ts
+++ b/utils/dependencies.ts
@@ -7,7 +7,7 @@ import fs from "fs";
 import log from "./log";
 
 const validateVersion = (version: string) => {
-    if (version === "latest") {
+    if (["latest", "unstable"].includes(version)) {
         return true;
     }
     const coerced = semverCoerce(version);


### PR DESCRIPTION
With this PR we add `unstable` as a valid package version, allowing us run upgrades and install packages while testing `unstable` releases.