### PR TITLE
feat: run upgrades with 0 as patch version

### DIFF
--- a/5.37.0/updateApiSecurityPlugins.ts
+++ b/5.37.0/updateApiSecurityPlugins.ts
@@ -1,9 +1,5 @@
 import { ObjectLiteralExpression, Project, SyntaxKind } from "ts-morph";
-import {
-    Files,
-    insertImportToSourceFile,
-    removeImportFromSourceFile
-} from "../utils";
+import { Files, insertImportToSourceFile, removeImportFromSourceFile } from "../utils";
 import { Context } from "../types";
 
 interface Params {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const forceMinorVersion = version => {
             "node_modules",
             "@webiny/cli/package.json"
         ));
-        cliVersion = semver.coerce(pkgJson.version).version;
+        cliVersion = pkgJson.version;
     } catch (e) {
         // Use the version passed through args.
     }

--- a/index.js
+++ b/index.js
@@ -9,89 +9,110 @@ require("ts-node").register({
 
 const fs = require("fs");
 const path = require("path");
-const { getDocsLink } = require("./utils");
+const {getDocsLink} = require("./utils");
 const log = require("./utils/log").default;
+const semver = require("semver");
 
 const response = data => {
-    console.log(JSON.stringify(data));
-    process.exit(0);
+	console.log(JSON.stringify(data));
+	process.exit(0);
 };
 
+const forceMinorVersion = (version) => {
+	const value = semver.coerce(version);
+	if(!value) {
+		return version;
+	}
+	return `${value.major}.${value.minor}.0`
+}
+
 (async () => {
-    const start = new Date();
-    const { argv } = require("yargs");
-    const [version] = argv._;
-
-    let cliVersion = version;
-    try {
-        const pkgJson = require(path.join(
-            process.cwd(),
-            "node_modules",
-            "@webiny/cli/package.json"
-        ));
-        cliVersion = pkgJson.version;
-    } catch (e) {
-        // Use the version passed through args.
-    }
-
-    try {
-        if (!version) {
-            throw new Error(`Missing positional "version" argument!`);
-        }
-
-        const scriptsPath = path.join(__dirname, version, `index`);
-
-        const scriptsJsPath = `${scriptsPath}.js`;
-        const scriptsTsPath = `${scriptsPath}.ts`;
-        if (!fs.existsSync(scriptsJsPath) && !fs.existsSync(scriptsTsPath)) {
-            response({
-                type: "error",
-                message: "Script does not exist.",
-                code: "SCRIPT_DOES_NOT_EXIST"
-            });
-        }
-
-        log.setDebug(argv.debug ?? false);
-
-        const context = {
-            project: {
-                root: argv.cwd || process.cwd()
-            },
-            version: cliVersion,
-            log: log
-        };
-
-        await require(scriptsPath)(context);
-
-        const duration = (new Date() - start) / 1000;
-        log.success(`Upgrade completed in %ss.`, duration);
-
-        console.log();
-
-        log.info("For more information about the upgrade, check out the following article:");
-        log.info(getDocsLink(`/release-notes/${version}/upgrade-guide/`));
-
-        response({ type: "success", message: "", error: null });
-    } catch (e) {
-        console.log(e);
-        const duration = (new Date() - start) / 1000;
-        log.error(`Upgrade completed in %ss.`, duration);
-
-        const [version] = argv._;
-        if (version) {
-            console.log();
-
-            log.info("For more information about the upgrade, check out the following article:");
-            log.info(getDocsLink(`/release-notes/${version}/upgrade-guide/`));
-        }
-
-        response({
-            type: "error",
-            message: e.message,
-            code: "ERROR",
-            data: {
-                stack: e.stack
-            }
+	const start = new Date();
+	const {argv} = require("yargs");
+	const [version] = argv._;
+	
+	let cliVersion = version;
+	try {
+		const pkgJson = require(path.join(
+			process.cwd(),
+			"node_modules",
+			"@webiny/cli/package.json"
+		));
+		cliVersion = semver.coerce(pkgJson.version).version;
+	}
+	catch (e) {
+		// Use the version passed through args.
+	}
+	
+	try {
+		if(!version) {
+			throw new Error(`Missing positional "version" argument!`);
+		}
+		
+		const forcedVersion = forceMinorVersion(version);
+		
+		const scriptsPath = path.join(__dirname, forcedVersion, `index`);
+		
+		const scriptsJsPath = `${scriptsPath}.js`;
+		const scriptsTsPath = `${scriptsPath}.ts`;
+		if(!fs.existsSync(scriptsJsPath) && !fs.existsSync(scriptsTsPath)) {
+			response({
+				type: "error",
+				message: "Script does not exist.",
+				code: "SCRIPT_DOES_NOT_EXIST"
+			});
+		}
+		
+		log.setDebug(argv.debug ?? false);
+		/**
+		 * There is a possibility that input version is not same as cli version.
+		 * Let's log that so users know that we are running upgrade script for the "0" patch version.
+		 */
+		if(forcedVersion !== cliVersion) {
+			log.debug(`We are running upgrade with "${forcedVersion}" version, which is different than cli version ${cliVersion}.`);
+			log.debug(`This is intentional, as we always want to run upgrade script for the "0" patch version.`);
+		}
+		
+		const context = {
+			project: {
+				root: argv.cwd || process.cwd()
+			},
+			version: cliVersion,
+			log: log
+		};
+		
+		await require(scriptsPath)(context);
+		
+		const duration = (new Date() - start) / 1000;
+		log.success(`Upgrade completed in %ss.`, duration);
+		
+		console.log();
+		
+		log.info("For more information about the upgrade, check out the following article:");
+		log.info(getDocsLink(`/release-notes/${version}/upgrade-guide/`));
+		
+		response({type: "success", message: "", error: null});
+	}
+	catch (e) {
+		console.log(e);
+		const duration = (new Date() - start) / 1000;
+		log.error(`Upgrade completed in %ss.`, duration);
+		
+		const [version] = argv._;
+		if(version) {
+			console.log();
+			
+			log.info("For more information about the upgrade, check out the following article:");
+			log.info(getDocsLink(`/release-notes/${version}/upgrade-guide/`));
+		}
+		
+		response({
+			type: "error",
+			message: e.message,
+			code: "ERROR",
+			data: {
+				stack: e.stack
+			}
         });
     }
 })();

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const response = data => {
     process.exit(0);
 };
 
-const forceMinorVersion = version => {
+const forcePatchVersion = version => {
     const value = semver.coerce(version);
     if (!value) {
         return version;
@@ -48,7 +48,7 @@ const forceMinorVersion = version => {
             throw new Error(`Missing positional "version" argument!`);
         }
 
-        const forcedVersion = forceMinorVersion(version);
+        const forcedVersion = forcePatchVersion(version);
 
         const scriptsPath = path.join(__dirname, forcedVersion, `index`);
 

--- a/index.js
+++ b/index.js
@@ -66,10 +66,12 @@ const forcePatchVersion = version => {
         /**
          * There is a possibility that input version is not same as cli version.
          * Let's log that so users know that we are running upgrade script for the "0" patch version.
+         *
+         * Debugging purposes only.
          */
         if (forcedVersion !== cliVersion) {
             log.debug(
-                `We are running upgrade with "${forcedVersion}" version, which is different than cli version ${cliVersion}.`
+                `We are running upgrade with "${forcedVersion}" version, which is different than CLI version ${cliVersion}.`
             );
             log.debug(
                 `This is intentional, as we always want to run upgrade script for the "0" patch version.`

--- a/index.js
+++ b/index.js
@@ -58,7 +58,11 @@ const forcePatchVersion = version => {
             response({
                 type: "error",
                 message: "Script does not exist.",
-                code: "SCRIPT_DOES_NOT_EXIST"
+                code: "SCRIPT_DOES_NOT_EXIST",
+                data: {
+                    version,
+                    forcedVersion
+                }
             });
         }
 

--- a/index.js
+++ b/index.js
@@ -9,110 +9,112 @@ require("ts-node").register({
 
 const fs = require("fs");
 const path = require("path");
-const {getDocsLink} = require("./utils");
+const { getDocsLink } = require("./utils");
 const log = require("./utils/log").default;
 const semver = require("semver");
 
 const response = data => {
-	console.log(JSON.stringify(data));
-	process.exit(0);
+    console.log(JSON.stringify(data));
+    process.exit(0);
 };
 
-const forceMinorVersion = (version) => {
-	const value = semver.coerce(version);
-	if(!value) {
-		return version;
-	}
-	return `${value.major}.${value.minor}.0`
-}
+const forceMinorVersion = version => {
+    const value = semver.coerce(version);
+    if (!value) {
+        return version;
+    }
+    return `${value.major}.${value.minor}.0`;
+};
 
 (async () => {
-	const start = new Date();
-	const {argv} = require("yargs");
-	const [version] = argv._;
-	
-	let cliVersion = version;
-	try {
-		const pkgJson = require(path.join(
-			process.cwd(),
-			"node_modules",
-			"@webiny/cli/package.json"
-		));
-		cliVersion = semver.coerce(pkgJson.version).version;
-	}
-	catch (e) {
-		// Use the version passed through args.
-	}
-	
-	try {
-		if(!version) {
-			throw new Error(`Missing positional "version" argument!`);
-		}
-		
-		const forcedVersion = forceMinorVersion(version);
-		
-		const scriptsPath = path.join(__dirname, forcedVersion, `index`);
-		
-		const scriptsJsPath = `${scriptsPath}.js`;
-		const scriptsTsPath = `${scriptsPath}.ts`;
-		if(!fs.existsSync(scriptsJsPath) && !fs.existsSync(scriptsTsPath)) {
-			response({
-				type: "error",
-				message: "Script does not exist.",
-				code: "SCRIPT_DOES_NOT_EXIST"
-			});
-		}
-		
-		log.setDebug(argv.debug ?? false);
-		/**
-		 * There is a possibility that input version is not same as cli version.
-		 * Let's log that so users know that we are running upgrade script for the "0" patch version.
-		 */
-		if(forcedVersion !== cliVersion) {
-			log.debug(`We are running upgrade with "${forcedVersion}" version, which is different than cli version ${cliVersion}.`);
-			log.debug(`This is intentional, as we always want to run upgrade script for the "0" patch version.`);
-		}
-		
-		const context = {
-			project: {
-				root: argv.cwd || process.cwd()
-			},
-			version: cliVersion,
-			log: log
-		};
-		
-		await require(scriptsPath)(context);
-		
-		const duration = (new Date() - start) / 1000;
-		log.success(`Upgrade completed in %ss.`, duration);
-		
-		console.log();
-		
-		log.info("For more information about the upgrade, check out the following article:");
-		log.info(getDocsLink(`/release-notes/${version}/upgrade-guide/`));
-		
-		response({type: "success", message: "", error: null});
-	}
-	catch (e) {
-		console.log(e);
-		const duration = (new Date() - start) / 1000;
-		log.error(`Upgrade completed in %ss.`, duration);
-		
-		const [version] = argv._;
-		if(version) {
-			console.log();
-			
-			log.info("For more information about the upgrade, check out the following article:");
-			log.info(getDocsLink(`/release-notes/${version}/upgrade-guide/`));
-		}
-		
-		response({
-			type: "error",
-			message: e.message,
-			code: "ERROR",
-			data: {
-				stack: e.stack
-			}
+    const start = new Date();
+    const { argv } = require("yargs");
+    const [version] = argv._;
+
+    let cliVersion = version;
+    try {
+        const pkgJson = require(path.join(
+            process.cwd(),
+            "node_modules",
+            "@webiny/cli/package.json"
+        ));
+        cliVersion = semver.coerce(pkgJson.version).version;
+    } catch (e) {
+        // Use the version passed through args.
+    }
+
+    try {
+        if (!version) {
+            throw new Error(`Missing positional "version" argument!`);
+        }
+
+        const forcedVersion = forceMinorVersion(version);
+
+        const scriptsPath = path.join(__dirname, forcedVersion, `index`);
+
+        const scriptsJsPath = `${scriptsPath}.js`;
+        const scriptsTsPath = `${scriptsPath}.ts`;
+        if (!fs.existsSync(scriptsJsPath) && !fs.existsSync(scriptsTsPath)) {
+            response({
+                type: "error",
+                message: "Script does not exist.",
+                code: "SCRIPT_DOES_NOT_EXIST"
+            });
+        }
+
+        log.setDebug(argv.debug ?? false);
+        /**
+         * There is a possibility that input version is not same as cli version.
+         * Let's log that so users know that we are running upgrade script for the "0" patch version.
+         */
+        if (forcedVersion !== cliVersion) {
+            log.debug(
+                `We are running upgrade with "${forcedVersion}" version, which is different than cli version ${cliVersion}.`
+            );
+            log.debug(
+                `This is intentional, as we always want to run upgrade script for the "0" patch version.`
+            );
+        }
+
+        const context = {
+            project: {
+                root: argv.cwd || process.cwd()
+            },
+            version: cliVersion,
+            log: log
+        };
+
+        await require(scriptsPath)(context);
+
+        const duration = (new Date() - start) / 1000;
+        log.success(`Upgrade completed in %ss.`, duration);
+
+        console.log();
+
+        log.info("For more information about the upgrade, check out the following article:");
+        log.info(getDocsLink(`/release-notes/${version}/upgrade-guide/`));
+
+        response({ type: "success", message: "", error: null });
+    } catch (e) {
+        console.log(e);
+        const duration = (new Date() - start) / 1000;
+        log.error(`Upgrade completed in %ss.`, duration);
+
+        const [version] = argv._;
+        if (version) {
+            console.log();
+
+            log.info("For more information about the upgrade, check out the following article:");
+            log.info(getDocsLink(`/release-notes/${version}/upgrade-guide/`));
+        }
+
+        response({
+            type: "error",
+            message: e.message,
+            code: "ERROR",
+            data: {
+                stack: e.stack
+            }
         });
     }
 })();

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -99,5 +99,5 @@ export {
     getRequireFromSourceFile,
     isPre529Project,
     getIsPre529Project,
-    findVersion,
+    findVersion
 };

--- a/utils/usesLatestPbRenderingEngine.ts
+++ b/utils/usesLatestPbRenderingEngine.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
+import fs from "fs";
 
 export const usesLatestPbRenderingEngine = (projectRoot = process.cwd()) => {
     const themeTsExists = fs.existsSync(`${projectRoot}/apps/theme/theme.ts`);
     const globalScssExists = fs.existsSync(`${projectRoot}/apps/theme/global.scss`);
 
     return themeTsExists && globalScssExists;
-}
+};


### PR DESCRIPTION
## Description
This PR forces a version, which we are running the upgrade for, to always be `x.x.0`.
This will allow users to run `5.37.0` upgrade on `5.37.5` versions.