### PR TITLE
Migrate `theme/src` and `reset.css` Abstraction Changes

### DIFF
--- a/5.40.0/index.ts
+++ b/5.40.0/index.ts
@@ -8,6 +8,7 @@ import { updateForRecordLocking } from "./updateForRecordLocking";
 import { updateForReact } from "./updateForReact";
 import { updateForWebsockets } from "./updateForWebsockets";
 import { updatesForExtensions } from "./updatesForExtensions";
+import {updatesForPbTheme} from "./updatesForPbTheme";
 
 module.exports = async (context: Context) => {
     const files = setupFiles(context);
@@ -47,6 +48,11 @@ module.exports = async (context: Context) => {
          * https://github.com/webiny/webiny-js/pull/4111
          */
         updatesForExtensions,
+
+        /**
+         * https://github.com/webiny/webiny-js/pull/4138
+         */
+        updatesForPbTheme,
 
     ];
 

--- a/5.40.0/index.ts
+++ b/5.40.0/index.ts
@@ -8,7 +8,7 @@ import { updateForRecordLocking } from "./updateForRecordLocking";
 import { updateForReact } from "./updateForReact";
 import { updateForWebsockets } from "./updateForWebsockets";
 import { updatesForExtensions } from "./updatesForExtensions";
-import {updatesForPbTheme} from "./updatesForPbTheme";
+import { updatesForPbTheme } from "./updatesForPbTheme";
 
 module.exports = async (context: Context) => {
     const files = setupFiles(context);
@@ -52,8 +52,7 @@ module.exports = async (context: Context) => {
         /**
          * https://github.com/webiny/webiny-js/pull/4138
          */
-        updatesForPbTheme,
-
+        updatesForPbTheme
     ];
 
     await processorsRunner.execute(processors);

--- a/5.40.0/setupFiles.ts
+++ b/5.40.0/setupFiles.ts
@@ -35,6 +35,21 @@ export const setupFiles = (context: Context) => {
             path: createFilePath(context, "${root}/webiny.project.ts"),
             tag: "root",
             name: "webiny.project.ts"
+        }),
+        createFileDefinition({
+            path: createFilePath(context, "${extensions}/theme/src/index.ts"),
+            tag: "extensions",
+            name: "extensions/theme/index"
+        }),
+        createFileDefinition({
+            path: createFilePath(context, "${website}/src/index.tsx"),
+            tag: "website",
+            name: "website/index"
+        }),
+        createFileDefinition({
+            path: createFilePath(context, "${website}/src/App.tsx"),
+            tag: "website",
+            name: "website/App"
         })
     ]);
 

--- a/5.40.0/updatesForExtensions.ts
+++ b/5.40.0/updatesForExtensions.ts
@@ -5,7 +5,7 @@ import {
     createProcessor,
     insertImportToSourceFile,
     removeWorkspaceFromRootPackageJson,
-    copyPaste,
+    copyPasteFiles,
     addWorkspaceToRootPackageJson,
     addPackagesToDependencies
 } from "../utils";
@@ -35,7 +35,7 @@ export const updatesForExtensions = createProcessor(async params => {
                 indexFile.path
             );
 
-            await copyPaste(src, dest);
+            await copyPasteFiles([{ src, dest }]);
 
             insertImportToSourceFile({
                 source,
@@ -78,7 +78,7 @@ export const updatesForExtensions = createProcessor(async params => {
                 indexFile.path
             );
 
-            await copyPaste(src, dest);
+            await copyPasteFiles([{ src, dest }]);
 
             insertImportToSourceFile({
                 source,
@@ -117,7 +117,7 @@ export const updatesForExtensions = createProcessor(async params => {
             context.log.warning("Skipping creation of %s folder, already exists.", dest);
         } else {
             context.log.info("Creating %s folder...", dest);
-            await copyPaste(src, dest);
+            await copyPasteFiles([{ src, dest }]);
         }
     }
 
@@ -130,7 +130,7 @@ export const updatesForExtensions = createProcessor(async params => {
             context.log.warning("Skipping moving %s folder to %s, already done.", src, dest);
         } else {
             context.log.info("Moving %s folder to %s...", src, dest);
-            await copyPaste(src, dest);
+            await copyPasteFiles([{ src, dest }]);
             fs.rmSync(src, { recursive: true });
 
             await removeWorkspaceFromRootPackageJson(["apps/theme"]);

--- a/5.40.0/updatesForPbTheme.ts
+++ b/5.40.0/updatesForPbTheme.ts
@@ -1,0 +1,113 @@
+import {
+    copyPasteFiles,
+    createProcessor,
+    insertImportToSourceFile,
+    moveFiles,
+    removeImportFromSourceFile
+} from "../utils";
+import glob from "fast-glob";
+import fs from "fs";
+import path from "path";
+import loadJson from "load-json-file";
+import { PackageJson } from "../types";
+import writeJson from "write-json-file";
+import { replaceInPath } from "replace-in-path";
+
+export const updatesForPbTheme = createProcessor(async params => {
+    const { project, files, context } = params;
+
+    // 1. Move all code in `extensions/theme` into `extensions/theme/src` folder.
+    {
+        fs.mkdirSync("extensions/theme/src", { recursive: true });
+        const filePaths = await glob([
+            "extensions/theme/**/*",
+            "!extensions/theme/package.json",
+            "!extensions/theme/tsconfig.json"
+        ]);
+
+        for (const filePath of filePaths) {
+            await moveFiles([
+                {
+                    src: filePath,
+                    dest: filePath.replace("extensions/theme/", "extensions/theme/src/")
+                }
+            ]);
+        }
+    }
+
+    // 2. Create a backup of the existing `global.scss` file, and replace it with the new one.
+    {
+        const globalScssPath = "extensions/theme/src/global.scss";
+        const globalScssBackupPath = "extensions/theme/src/global.backup.scss";
+        await moveFiles([{ src: globalScssPath, dest: globalScssBackupPath }]);
+
+        const src = path.join(__dirname, "updatesForPbTheme", "filesToCopy", "global.scss");
+        const dest = path.join("extensions", "theme", "src", "global.scss");
+        await copyPasteFiles([{ src, dest }]);
+    }
+
+    // 3. Update `package.json` and `tsconfig.json` files (take into consideration the new `src` folder).
+    {
+        const packageJsonPath = path.join("extensions", "theme", "package.json");
+        const packageJson = await loadJson<PackageJson>(packageJsonPath);
+        packageJson.main = "src/index.ts";
+        await writeJson(packageJsonPath, packageJson);
+    }
+
+    {
+        const packageJsonPath = path.join("extensions", "theme", "tsconfig.json");
+        const tsConfigJson = await loadJson<Record<string, any>>(packageJsonPath);
+        tsConfigJson.include = ["src"];
+        await writeJson(packageJsonPath, tsConfigJson);
+    }
+
+    // 4. Import `global.scss` in `extensions/theme/src/index.ts`.
+    {
+        // Had to re-add the file because initially the file does not exist. It
+        // only gets added during the project upgrade process.
+        const indexFile = files.byName("extensions/theme/index");
+        project.addSourceFileAtPath(indexFile.path);
+
+        const source = project.getSourceFile(indexFile.path);
+
+        insertImportToSourceFile({
+            source,
+            moduleSpecifier: "./global.scss",
+            after: "@webiny/app-website"
+        });
+    }
+
+    {
+        // 5. Also remove imports of `global.scss` from `apps/admin` and `apps/website`.
+        const adminAppFile = "apps/admin/src/App.scss";
+        replaceInPath(adminAppFile, [
+            {
+                find: `// Import theme styles`,
+                replaceWith: ""
+            },
+            {
+                find: `@import "~theme/global.scss";`,
+                replaceWith: ""
+            }
+        ]);
+
+        const websiteIndexFile = files.byName("website/index");
+        const source = project.getSourceFile(websiteIndexFile.path);
+
+        removeImportFromSourceFile(source, `theme/global.scss`);
+    }
+    {
+        // 6. Create new `App.scss` in `apps/website` and import it in `App.tsx`.
+        const src = path.join(__dirname, "updatesForPbTheme", "filesToCopy", "App.scss");
+        const dest = path.join("apps", "website", "src", "App.scss");
+        await copyPasteFiles([{ src, dest }]);
+
+        const websiteAppFile = files.byName("website/App");
+        const source = project.getSourceFile(websiteAppFile.path);
+        insertImportToSourceFile({
+            source,
+            moduleSpecifier: "./App.scss",
+            after: "@webiny/app-website"
+        });
+    }
+});

--- a/5.40.0/updatesForPbTheme/filesToCopy/App.scss
+++ b/5.40.0/updatesForPbTheme/filesToCopy/App.scss
@@ -1,0 +1,1 @@
+@import "~@webiny/app-website/styles.scss";

--- a/5.40.0/updatesForPbTheme/filesToCopy/global.scss
+++ b/5.40.0/updatesForPbTheme/filesToCopy/global.scss
@@ -1,0 +1,16 @@
+// ***** 5.40.0 Migration Note *****
+// The existing `global.scss` file has been replaced by this file.
+// Note that a backup of the existing `global.scss` file has been
+// created at `global.backup.scss`. If you need to restore the
+// some of the styles from the old file, you can do so manually.
+// The `global.backup.scss` can be deleted once you've copied
+// the styles you need from it (if any).
+
+// Styles for the rich text editor that's used with Form Builder.
+@import "@webiny/react-rich-text-renderer/styles.scss";
+
+// Font used with the default theme.
+@import url("https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,500,700|Lato:400,700");
+
+// CSS reset styles that were previously here are no longer required.
+// They are now maintained internally by the Webiny team.

--- a/types.ts
+++ b/types.ts
@@ -33,6 +33,7 @@ export type FileDefinitionTag =
     | "gql"
     | "ps"
     | "ddb2es"
+    | "extensions"
     | "theme"
     | "website"
     | "admin"
@@ -51,11 +52,16 @@ export interface IFileDefinition {
 export interface IFilesFilterCb {
     (file: IFileDefinition): boolean;
 }
+
 export interface IFiles {
     byName(name: string): IFileDefinition | null;
+
     byTag(tag: FileDefinitionTag): IFiles;
+
     filter(cb: IFilesFilterCb): IFiles;
+
     relevant: () => IFiles;
+
     paths(): string[];
 }
 

--- a/utils/copyPaste.ts
+++ b/utils/copyPaste.ts
@@ -1,7 +1,0 @@
-const util = require("util");
-const ncpBase = require("ncp");
-const ncp = util.promisify(ncpBase.ncp);
-
-export const copyPaste = async (src: string, dest: string) => {
-    await ncp(src, dest);
-};

--- a/utils/copyPasteFiles.ts
+++ b/utils/copyPasteFiles.ts
@@ -1,0 +1,27 @@
+import util from "util";
+import ncpBase from "ncp";
+import fs from "fs";
+import path from "path";
+
+const ncp = util.promisify(ncpBase.ncp);
+
+export const copyPasteFiles = async (
+    files: Array<{ src: string; dest: string }>,
+    options?: { deleteSrc: boolean }
+) => {
+    for (const file of files) {
+        if (!fs.existsSync(file.src)) {
+            throw new Error(`File "${file.src}" does not exist.`);
+        }
+
+        const destFolderPath = path.dirname(file.dest);
+        if (!fs.existsSync(destFolderPath)) {
+            fs.mkdirSync(destFolderPath, { recursive: true });
+        }
+
+        await ncp(file.src, file.dest);
+        if (options?.deleteSrc) {
+            fs.unlinkSync(file.src);
+        }
+    }
+};

--- a/utils/createNamedImports.ts
+++ b/utils/createNamedImports.ts
@@ -1,4 +1,4 @@
-interface NamedImport {
+export interface NamedImport {
     name: string;
     alias?: string;
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -15,6 +15,7 @@ import { removeImportFromSourceFile } from "./removeImportFromSourceFile";
 import { removePluginFromCreateHandler } from "./removePluginFromCreateHandler";
 import { removeWorkspaceFromRootPackageJson } from "./removeWorkspaceFromRootPackageJson";
 import { yarnInstall } from "./yarnInstall";
+
 export * from "./yarnUp";
 import { removePulumiCache } from "./removePulumiCache";
 import { addDynamoDbDocumentClient } from "./addDynamoDbDocumentClient";
@@ -33,7 +34,8 @@ import { removeExtendsFromInterface } from "./removeExtendsFromInterface";
 import { getExistingFiles, getSourceFile } from "./files";
 import { addToExportDefaultArray } from "./addToExportDefaultArray";
 import { getRequireFromSourceFile } from "./getRequireFromSourceFile";
-import { copyPaste } from "./copyPaste";
+import { copyPasteFiles } from "./copyPasteFiles";
+import { moveFiles } from "./moveFiles";
 import { getIsPre529Project, isPre529Project } from "./isPre529Project";
 import { findVersion } from "./findVersion";
 import {
@@ -105,7 +107,8 @@ export {
     getExistingFiles,
     addToExportDefaultArray,
     getRequireFromSourceFile,
-    copyPaste,
+    copyPasteFiles,
+    moveFiles,
     isPre529Project,
     getIsPre529Project,
     findVersion

--- a/utils/insertImportToSourceFile.ts
+++ b/utils/insertImportToSourceFile.ts
@@ -1,5 +1,5 @@
 import { SourceFile } from "ts-morph";
-import { createNamedImports } from "./createNamedImports";
+import { createNamedImports, NamedImport } from "./createNamedImports";
 
 interface BaseParams {
     source: SourceFile;
@@ -9,7 +9,7 @@ interface BaseParams {
      * - string[] - will produce named imports
      * - Record<string, string> - will produce named imports with aliases
      */
-    name: string | string[] | Record<string, string>;
+    name?: string | string[] | Record<string, string>;
     moduleSpecifier: string;
 }
 
@@ -26,8 +26,14 @@ interface ParamsAfter extends BaseParams {
 export type IInsertInputToSourceFile = ParamsBefore | ParamsAfter;
 export const insertImportToSourceFile = (params: IInsertInputToSourceFile): void => {
     const { source, name, moduleSpecifier, after = null, before = null } = params;
-    const namedImports = createNamedImports(name);
-    const defaultImport = namedImports === undefined ? (name as string) : undefined;
+
+    let namedImports: NamedImport[] = [];
+    let defaultImport: string | undefined;
+
+    if (name) {
+        namedImports = createNamedImports(name);
+        defaultImport = namedImports === undefined ? (name as string) : undefined;
+    }
 
     const declaration = source.getImportDeclaration(moduleSpecifier);
 
@@ -61,6 +67,7 @@ export const insertImportToSourceFile = (params: IInsertInputToSourceFile): void
         declaration.addNamedImports(newImports);
         return;
     }
+
     if (before) {
         const beforeDeclaration = source.getImportDeclaration(before);
         if (beforeDeclaration) {

--- a/utils/moveFiles.ts
+++ b/utils/moveFiles.ts
@@ -1,0 +1,7 @@
+import { copyPasteFiles } from "./copyPasteFiles";
+
+export const moveFiles = async (files: Array<{ src: string; dest: string }>) => {
+    for (const file of files) {
+        await copyPasteFiles([{ src: file.src, dest: file.dest }], { deleteSrc: true });
+    }
+};

--- a/utils/paths.ts
+++ b/utils/paths.ts
@@ -62,6 +62,10 @@ export const getThemePath = () => {
     return "apps/theme";
 };
 
+export const getExtensionsPath = () => {
+    return "extensions";
+};
+
 interface PathConverters {
     [key: string]: {
         (context: Context): string;
@@ -80,7 +84,8 @@ const pathConverters: PathConverters = {
     "${dynamoToElastic}": getDynamoDbToElasticsearchPath,
     "${website}": getWebsitePath,
     "${theme}": getThemePath,
-    "${admin}": getAdminPath
+    "${admin}": getAdminPath,
+    "${extensions}": getExtensionsPath
 };
 
 export const createFilePath = (context: Context, file: string): string | null => {


### PR DESCRIPTION
We've added an extra step in the 5.40 project upgrade script which ensures the latest `theme/src` and `reset.css` abstraction changes are also made in users' projects.